### PR TITLE
Make exceptions for network calls more user-friendly

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -16,8 +16,8 @@ required = True
 local_path = MICM_chemistry
 
 [Mechanism_collection]
-tag = 95eb1c8ce79dd5c4e3ee331e9cc9e140a372e91d
+tag = bdcf4dec5c8955a62b3e4560aa0b269d8b2246b1
 protocol = git
-repo_url = https://github.com/NCAR/burrito
+repo_url = https://github.com/NCAR/Mechanism_Collection
 required = True
 local_path = Mechanism_collection


### PR DESCRIPTION
Update Externals for Mechanism_Collection
Exception handling for get_tag.py from the Mechanism_Collection has been made more user-friendly.  
Also changed name of repository from burrito to Mechanism_Collection.

closes #74 